### PR TITLE
Feat: TP-6595 - Use concrete models for relationship targets

### DIFF
--- a/DTDL/V2/base-stream.json
+++ b/DTDL/V2/base-stream.json
@@ -87,7 +87,7 @@
       "name": "Options",
       "minMultiplicity": 0,
       "maxMultiplicity": 500,
-      "target": "dtmi:io:tributech:options:valuechange",
+      "target": "dtmi:io:tributech:options:valuechange;2",
       "displayName": "Options",
       "description": "Attach value change options to the stream to configure its properties."
     }

--- a/DTDL/V2/edge/edge.json
+++ b/DTDL/V2/edge/edge.json
@@ -28,7 +28,7 @@
       "name": "MqttSource",
       "minMultiplicity": 0,
       "maxMultiplicity": 1,
-      "target": "dtmi:io:tributech:source:mqtt",
+      "target": "dtmi:io:tributech:source:mqtt;2",
       "displayName": "Sources",
       "description": "Contain MQTT source of the given device."
     },
@@ -37,7 +37,7 @@
       "name": "OpcUaSource",
       "minMultiplicity": 0,
       "maxMultiplicity": 1,
-      "target": "dtmi:io:tributech:source:opcua",
+      "target": "dtmi:io:tributech:source:opcua;2",
       "displayName": "Sources",
       "description": "Contain OPC UA source of the given device."
     },
@@ -46,7 +46,7 @@
       "name": "RestSource",
       "minMultiplicity": 0,
       "maxMultiplicity": 1,
-      "target": "dtmi:io:tributech:source:rest",
+      "target": "dtmi:io:tributech:source:rest;2",
       "displayName": "Sources",
       "description": "Contain REST source of the given device."
     }, 
@@ -55,7 +55,7 @@
       "name": "SimulatedSource",
       "minMultiplicity": 0,
       "maxMultiplicity": 1,
-      "target": "dtmi:io:tributech:source:simulated",
+      "target": "dtmi:io:tributech:source:simulated;2",
       "displayName": "Sources",
       "description": "Contain simulated source of the given device."
     }, 
@@ -64,7 +64,7 @@
       "name": "TcadsSource",
       "minMultiplicity": 0,
       "maxMultiplicity": 1,
-      "target": "dtmi:io:tributech:source:tcads",
+      "target": "dtmi:io:tributech:source:tcads;2",
       "displayName": "Sources",
       "description": "Contain ADS source of the given device."
     }

--- a/DTDL/V2/edge/mqtt/mqtt-jsonpathcollection.json
+++ b/DTDL/V2/edge/mqtt/mqtt-jsonpathcollection.json
@@ -25,7 +25,7 @@
       "name": "Streams",
       "minMultiplicity": 0,
       "maxMultiplicity": 500,
-      "target": "dtmi:io:tributech:stream:mqtt:jsonpath",
+      "target": "dtmi:io:tributech:stream:mqtt:jsonpath;2",
       "displayName": "Streams",
       "description": "JSONPath streams processing messages from this topic."
     }

--- a/DTDL/V2/edge/mqtt/mqtt-source.json
+++ b/DTDL/V2/edge/mqtt/mqtt-source.json
@@ -26,7 +26,7 @@
       "name": "PayloadStreams",
       "minMultiplicity": 0,
       "maxMultiplicity": 500,
-      "target": "dtmi:io:tributech:stream:mqtt:payload",
+      "target": "dtmi:io:tributech:stream:mqtt:payload;2",
       "displayName": "Payload Streams",
       "description": "Contains all MQTT Payload streams in the given source."
     }, 
@@ -35,7 +35,7 @@
       "name": "TopicStreams",
       "minMultiplicity": 0,
       "maxMultiplicity": 500,
-      "target": "dtmi:io:tributech:stream:mqtt:topic",
+      "target": "dtmi:io:tributech:stream:mqtt:topic;2",
       "displayName": "Topic Streams",
       "description": "Contains all MQTT Topic streams in the given source."
     }, 
@@ -44,7 +44,7 @@
       "name": "JsonPathCollections",
       "minMultiplicity": 0,
       "maxMultiplicity": 100,
-      "target": "dtmi:io:tributech:mqtt:jsonpathcollection",
+      "target": "dtmi:io:tributech:mqtt:jsonpathcollection;2",
       "displayName": "JsonPath Collection",
       "description": "Contains topic-specific configurations for associated jsonpath based streams."
     }

--- a/DTDL/V2/edge/opcua/opcua-source.json
+++ b/DTDL/V2/edge/opcua/opcua-source.json
@@ -26,7 +26,7 @@
       "name": "Streams",
       "minMultiplicity": 0,
       "maxMultiplicity": 10,
-      "target": "dtmi:io:tributech:stream:opcua",
+      "target": "dtmi:io:tributech:stream:opcua;2",
       "displayName": "Streams",
       "description": "Contains all OPC UA streams the given source."
     }

--- a/DTDL/V2/edge/rest/rest-source.json
+++ b/DTDL/V2/edge/rest/rest-source.json
@@ -19,7 +19,7 @@
       "name": "Streams",
       "minMultiplicity": 0,
       "maxMultiplicity": 500,
-      "target": "dtmi:io:tributech:stream:rest:stream",
+      "target": "dtmi:io:tributech:stream:rest:stream;2",
       "displayName": "Streams",
       "description": "Contains all REST streams in the given source."
     }

--- a/DTDL/V2/edge/rest/rest-source.json
+++ b/DTDL/V2/edge/rest/rest-source.json
@@ -10,7 +10,7 @@
       "name": "PredefinedPayloadStreams",
       "minMultiplicity": 0,
       "maxMultiplicity": 500,
-      "target": "dtmi:io:tributech:stream:rest:payload",
+      "target": "dtmi:io:tributech:stream:rest:payload;2",
       "displayName": "Streams",
       "description": "Contains all REST Payload streams in the given source."
     }, 

--- a/DTDL/V2/edge/simulated/simulated-source.json
+++ b/DTDL/V2/edge/simulated/simulated-source.json
@@ -26,7 +26,7 @@
             "name": "Streams",
             "minMultiplicity": 0,
             "maxMultiplicity": 10,
-            "target": "dtmi:io:tributech:stream:simulated",
+            "target": "dtmi:io:tributech:stream:simulated;2",
             "displayName": "Streams",
             "description": "Contains all Simulated streams the given source."
         }, 

--- a/DTDL/V2/edge/tcads/tcads-source.json
+++ b/DTDL/V2/edge/tcads/tcads-source.json
@@ -66,7 +66,7 @@
             "name" :"Streams", 
             "minMultiplicity" : 0, 
             "maxMultiplicity" : 100,
-            "target": "dtmi:io:tributech:stream:tcads",
+            "target": "dtmi:io:tributech:stream:tcads;2",
             "displayName" : "Streams",
             "description" : "Contains all the TwinCat ADS streams at the given Source"
         },
@@ -75,7 +75,7 @@
             "name" :"Parameter", 
             "minMultiplicity" : 0, 
             "maxMultiplicity" : 100,
-            "target": "dtmi:io:tributech:parameter:tcads",
+            "target": "dtmi:io:tributech:parameter:tcads;2",
             "displayName" : "Parameters",
             "description" : "For writing Configuration Values to the ADS Server"
         }, 

--- a/DTDL/V2/sdk/sdk-source.json
+++ b/DTDL/V2/sdk/sdk-source.json
@@ -10,7 +10,7 @@
         "name": "Streams",
         "minMultiplicity": 0,
         "maxMultiplicity": 15,
-        "target": "dtmi:io:tributech:stream:sdk",
+        "target": "dtmi:io:tributech:stream:sdk;2",
         "displayName": "Streams",
         "description": "Contains all streams of the given source."
       },
@@ -19,7 +19,7 @@
         "name": "Parameters",
         "minMultiplicity": 0,
         "maxMultiplicity": 15,
-        "target": "dtmi:io:tributech:parameter:sdk",
+        "target": "dtmi:io:tributech:parameter:sdk;2",
         "displayName": "Parameter",
         "description": "Contains all parameters of the given source."
       }

--- a/DTDL/V2/sdk/sdk.json
+++ b/DTDL/V2/sdk/sdk.json
@@ -10,7 +10,7 @@
       "name": "Sources",
       "minMultiplicity": 0,
       "maxMultiplicity": 100,
-      "target": "dtmi:io:tributech:source:sdk",
+      "target": "dtmi:io:tributech:source:sdk;2",
       "displayName": "Sources",
       "description": "Contains all sources of the given device."
     }


### PR DESCRIPTION
Without the version for relationship targets, the model/validate succeed but graph/validate fails.

In [model/validate]( https://github.com/tributech-solutions/tributech-demeter/blob/5d341ce135dabc0321cf186ea3b05bf47708d9af/src/Tributech.Demeter.Application/Twins/DTDLModel/BaseDTDLModelHandler.cs#L84), we were only validating the DTDL model structure and references (like extends and components), but do not check if relationship targets are valid or if relationships are correctly defined.

The DTDL doc says version can be omitted entirely(https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v4/DTDL.v4.md#digital-twin-model-identifier:~:text=The%20version%20(and%20the%20preceding%20semicolon,1.0%20since%20the%20latter%20is%20invalid.), but it doesnot mention anywhere that it has the capability to automatically fetch a latest version of model, by not specifying version for a item, which is defined with the versions. 