### PR TITLE
Feat: TP-6901-Twincleared healthindicator

### DIFF
--- a/DTDL/V3/edge/edge-health-message.json
+++ b/DTDL/V3/edge/edge-health-message.json
@@ -82,6 +82,16 @@
       "annotates": "HealthState",
       "schema": "double",
       "description": "Current DLQ utilization percentage (0-100)."
+    }, 
+    {
+      "@type": [
+        "Telemetry",
+        "ValueAnnotation"
+      ],
+      "name": "TwinWasClearedDueToEnrollmentFailure",
+      "annotates": "HealthState",
+      "schema": "boolean",
+      "description": "Indicates if the twin was cleared due to enrollment failure."
     }
   ]
 }


### PR DESCRIPTION
New health indicator TwinWasClearedDueToEnrollmentFailure added to edge health message