### PR TITLE
Feat: TP-7354 Windowed health indicators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# data-asset-twin-v2
+
+DTDL (Digital Twins Definition Language) model definitions for the Tributech Node / Tributech Edge Agent. This repo is pure data — JSON DTDL interface files, no build/test tooling.
+
+## Repo layout
+
+- `DTDL/V1`, `DTDL/V2`, `DTDL/V3`, `DTDL/V4` — versioned model folders, described below.
+- `vocabulary.json`, `vocabulary-v2.json`, `vocabulary-v3.json`, `vocabulary-v4.json` — one vocabulary manifest per `DTDL/Vn` folder (see "Vocabulary files").
+- `examples/` — example DTDL digital twin instances (`$metadata.$model` references) showing how models are used together, e.g. [ads-demo.json](examples/ads-demo.json), [opcua-demo.json](examples/opcua-demo.json).
+
+## Versioning model (important — read before adding/editing any interface)
+
+Every DTDL interface has a DTMI in the form:
+
+```
+dtmi:io:tributech:<category>:<name>;<version>
+```
+
+e.g. `dtmi:io:tributech:device:edge;4`, `dtmi:io:tributech:healthmessage:edge;2`, `dtmi:io:tributech:source:opcua;4`.
+
+**The trailing `;N` is a per-model version counter, not the folder number.** Rules:
+
+- A brand new model starts at `;1` in whichever `DTDL/Vx` folder it's first introduced in.
+- When an existing model is changed, its version increments by exactly 1 and the new file is placed in the current/next `DTDL/Vx` folder.
+- If a model is *not* changed for a given release, it is **not duplicated** into the new `Vx` folder — the old file (and its old `;N`) simply keeps being referenced from its original folder via `extends`/`schema`/`target`.
+
+Example: `dtmi:io:tributech:device:base` was introduced as `;1` in `DTDL/V1/base-device.json`, bumped to `;2` in `DTDL/V2/base-device.json`, and has not changed since — there is no `base-device.json` in `DTDL/V3` or `DTDL/V4`; `edge.json` in those folders still does `"extends": "dtmi:io:tributech:device:base;2"`.
+
+Another example: `dtmi:io:tributech:healthmessage:edge` was introduced as `;1` in [DTDL/V3/edge/edge-health-message.json](DTDL/V3/edge/edge-health-message.json), then changed and bumped to `;2` in [DTDL/V4/edge/edge-health-message.json](DTDL/V4/edge/edge-health-message.json) (Snapshot/Windowed telemetry restructure).
+
+So: **the folder a file lives in tells you where it was last touched, not what its version number is.** Always check the actual `@id` in the file (or grep for the DTMI) rather than assuming `;N` == folder number `N`. In practice many "core" models (`device:edge`, `source:opcua`, ...) happen to have changed in every release so far, so their `;N` does line up with the folder number — but that's a coincidence of history, not a rule, and `device:base` above already breaks it.
+
+When adding a new version of a model:
+1. Copy the file into the current `DTDL/Vx` folder (create the folder if starting a new version line).
+2. Bump `@id`'s `;N` by 1.
+3. Bump `;N` in every other file's `extends`/`schema`/`target`/`request`/`response` reference that points at the old version, **only if** that referencing file is also being updated in this release. Otherwise leave older references pointing at the old version until that file's owner updates it.
+4. Add the new file's raw GitHub URL to the corresponding `vocabulary-vX.json`.
+
+## `@context` conventions
+
+- `DTDL/V1/**` uses DTDL spec v2: `"@context": "dtmi:dtdl:context;2"`.
+- `DTDL/V2/**`, `DTDL/V3/**`, `DTDL/V4/**` use DTDL spec v4: `"@context": "dtmi:dtdl:context;4"`.
+- Any interface that uses `ValueAnnotation` (i.e. telemetry/property annotated with `"annotates": "..."`, used heavily by health-message interfaces) must add the annotation extension to `@context` as an array:
+  ```json
+  "@context": ["dtmi:dtdl:context;4", "dtmi:dtdl:extension:annotation;2"]
+  ```
+  See [DTDL/V3/edge/edge-health-message.json](DTDL/V3/edge/edge-health-message.json) or [DTDL/V4/edge/edge-health-message.json](DTDL/V4/edge/edge-health-message.json). Interfaces without `ValueAnnotation` content use the plain single-string context.
+
+## Vocabulary files (`vocabulary*.json`)
+
+Each `vocabulary-vN.json` (and the unsuffixed `vocabulary.json` for V1) is a manifest listing the raw GitHub URLs of the DTDL files that belong to that version line — **not** a cumulative "latest state" list. `vocabulary-v4.json` currently only lists the 4 OPC UA files that exist under `DTDL/V4` (it doesn't re-list unchanged files from V1–V3). To resolve the *complete, current* model set for a consumer, you conceptually need to overlay `vocabulary.json` → `vocabulary-v2.json` → `vocabulary-v3.json` → `vocabulary-v4.json`, with later entries superseding earlier ones for the same DTMI base name.
+
+When adding a new file to a `DTDL/Vx` folder, always add its raw URL to the matching `vocabulary-vX.json` (`vocabulary.json` for V1).
+
+## Naming/category conventions
+
+DTMI categories in use: `device`, `source`, `stream`, `parameter`, `options`, `healthmessage`, `command:response`, `sdk`, `oem`. Folder layout under each `DTDL/Vx` groups by transport/protocol (`edge/mqtt`, `edge/opcua`, `edge/rest`, `edge/simulated`, `edge/tcads`, `edge/syslog`, `edge/modbus`, `oem/emb`, `sdk`), each typically providing a `*-source.json`, `*-stream*.json`, optionally `*-parameter.json` and `*-health-message.json`.

--- a/DTDL/V3/edge/edge-health-message.json
+++ b/DTDL/V3/edge/edge-health-message.json
@@ -53,7 +53,7 @@
       "schema": {
         "@type": "Array",
         "elementSchema": "string"
-    },
+      },
       "displayName": "Age Limit Hit Streams",
       "description": "Streams for which the merkle tree age hit limit instead of depth."
     },
@@ -89,7 +89,7 @@
       "schema": "double",
       "displayName": "DLQ Queue Percentage",
       "description": "Current DLQ utilization percentage (0-100)."
-    }, 
+    },
     {
       "@type": [
         "Telemetry",

--- a/DTDL/V4/edge/edge-health-message.json
+++ b/DTDL/V4/edge/edge-health-message.json
@@ -1,0 +1,125 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:annotation;2"
+  ],
+  "@id": "dtmi:io:tributech:healthmessage:edge;2",
+  "@type": "Interface",
+  "extends": [
+    "dtmi:io:tributech:healthmessage:base;1"
+  ],
+  "displayName": "Agent Health",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "ValueAnnotation"
+      ],
+      "name": "Snapshot",
+      "annotates": "HealthState",
+      "displayName": "Snapshot",
+      "description": "Point-in-time health readings taken at tick time.",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "IsConnectedToSourceBroker",
+            "schema": "boolean",
+            "displayName": "Is Connected To Source Broker",
+            "description": "Agent connection to source broker."
+          },
+          {
+            "name": "IsConnectedToCloudBroker",
+            "schema": "boolean",
+            "displayName": "Is Connected To Cloud Broker",
+            "description": "Agent connection to node/cloud broker."
+          },
+          {
+            "name": "EnrollmentCertificatesExist",
+            "schema": "boolean",
+            "displayName": "Enrollment Certificates Exist",
+            "description": "States if enrollment certificates available with the agent."
+          },
+          {
+            "name": "IsSourceMqttClientHealthy",
+            "schema": "boolean",
+            "displayName": "Is Source MQTT Client Healthy",
+            "description": "Is internal health of the Source-side MQTT client in Agent healthy."
+          },
+          {
+            "name": "IsNodeMqttClientHealthy",
+            "schema": "boolean",
+            "displayName": "Is Node MQTT Client Healthy",
+            "description": "Is internal health of the Node-side MQTT client in Agent healthy."
+          },
+          {
+            "name": "DlqQueuePercentage",
+            "schema": "double",
+            "displayName": "DLQ Queue Percentage",
+            "description": "Current DLQ utilization percentage (0-100)."
+          }
+        ]
+      }
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "ValueAnnotation"
+      ],
+      "name": "Windowed",
+      "annotates": "HealthState",
+      "displayName": "Windowed",
+      "description": "Windowed health observations accumulated since the last health tick.",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "TwinWasClearedDueToEnrollmentFailureCount",
+            "schema": "integer",
+            "displayName": "Twin Cleared Due To Enrollment Failure Count",
+            "description": "Number of times the twin was cleared due to enrollment failure since the last health tick."
+          },
+          {
+            "name": "AgeLimitHitStreams",
+            "schema": {
+              "@type": "Array",
+              "elementSchema": "string"
+            },
+            "displayName": "Age Limit Hit Streams",
+            "description": "Streams for which the merkle tree age hit limit instead of depth."
+          },
+          {
+            "name": "SourceBrokerDisconnectionCount",
+            "schema": "integer",
+            "displayName": "Source Broker Disconnection Count",
+            "description": "Number of times the agent was disconnected from the source broker since the last health tick."
+          },
+          {
+            "name": "NodeBrokerDisconnectionCount",
+            "schema": "integer",
+            "displayName": "Node Broker Disconnection Count",
+            "description": "Number of times the agent was disconnected from the node/cloud broker since the last health tick."
+          },
+          {
+            "name": "SourceMqttClientWasUnhealthyCount",
+            "schema": "integer",
+            "displayName": "Source MQTT Client Was Unhealthy Count",
+            "description": "Number of times the Source-side MQTT client in Agent was unhealthy since the last health tick."
+          },
+          {
+            "name": "NodeMqttClientWasUnhealthyCount",
+            "schema": "integer",
+            "displayName": "Node MQTT Client Was Unhealthy Count",
+            "description": "Number of times the Node-side MQTT client in Agent was unhealthy since the last health tick."
+          },
+          {
+            "name": "DlqFullCount",
+            "schema": "integer",
+            "displayName": "DLQ Full Count",
+            "description": "Number of times the DLQ reached full capacity since the last health tick."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/DTDL/V4/edge/edge.json
+++ b/DTDL/V4/edge/edge.json
@@ -1,0 +1,79 @@
+{
+  "@context": "dtmi:dtdl:context;4",
+  "@id": "dtmi:io:tributech:device:edge;4",
+  "extends": "dtmi:io:tributech:device:base;2",
+  "@type": "Interface",
+  "displayName": "Edge",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "MaxMerkleTreeDepth",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Max Merkle Tree Depth",
+      "description": "Maximum depth of the binary merkle-tree used for proof generation (e.g. 12). Value used as 2^MerkleTreeDepth.",
+      "comment": "Proofs allows to verify integrity and origin of the stream. A proof represents a binary-merkle-tree and 2^MerkleTreeDepth values are necessary to build a single proof."
+    },
+    {
+      "@type": "Property",
+      "name": "MaxMerkleTreeAge",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Max Merkle Tree Age",
+      "description": "Maximum merkle tree age in seconds (e.g. 600).",
+      "comment": "If a stream doesn't provides enough values to build an entire merkle tree with the given depth in the given time-period it will be splitted into smaller merkle trees."
+    },
+    {
+      "@type": "Component",
+      "name": "Health",
+      "schema": "dtmi:io:tributech:healthmessage:edge;2",
+      "displayName": "Agent Health",
+      "description": "Health message with edge agent specific health information."
+    },
+    {
+      "@type": "Relationship",
+      "name": "MqttSource",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 1,
+      "target": "dtmi:io:tributech:source:mqtt",
+      "displayName": "Sources",
+      "description": "Contain MQTT source of the given device."
+    },
+    {
+      "@type": "Relationship",
+      "name": "OpcUaSource",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 1,
+      "target": "dtmi:io:tributech:source:opcua",
+      "displayName": "Sources",
+      "description": "Contain OPC UA source of the given device."
+    },
+    {
+      "@type": "Relationship",
+      "name": "RestSource",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 1,
+      "target": "dtmi:io:tributech:source:rest",
+      "displayName": "Sources",
+      "description": "Contain REST source of the given device."
+    },
+    {
+      "@type": "Relationship",
+      "name": "SimulatedSource",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 1,
+      "target": "dtmi:io:tributech:source:simulated",
+      "displayName": "Sources",
+      "description": "Contain simulated source of the given device."
+    },
+    {
+      "@type": "Relationship",
+      "name": "TcadsSource",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 1,
+      "target": "dtmi:io:tributech:source:tcads",
+      "displayName": "Sources",
+      "description": "Contain ADS source of the given device."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 The Tributech Node follows the approach of describing all entities of the system and their relations using the open-source [Digital Twins Definition Language (DTDL)](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v4/DTDL.v4.md) standard.
 
-Currently we support both [DTDL v2](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/dtdlv2.md) (DTDL/V1 folder) and [DTDL v4](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v4/DTDL.v4.md) (DTDL/V2 folder)
+Currently we support both [DTDL v2](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/dtdlv2.md) (DTDL/V1 folder) and [DTDL v4](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v4/DTDL.v4.md) (DTDL/V2, DTDL/V3 and DTDL/V4 folders).
+
+## Versioning
+
+Each `DTDL/Vx` folder holds the models that were introduced or changed for that release — a model only reappears in a newer `Vx` folder if it actually changed; otherwise older interfaces keep referencing it at its last version. Each release also has a matching `vocabulary*.json` manifest (`vocabulary.json` for V1, `vocabulary-v2.json`, `vocabulary-v3.json`, `vocabulary-v4.json`) listing the raw file URLs added or changed in that version. See [CLAUDE.md](CLAUDE.md) for the full versioning and `@context` conventions.
 
 ## Tooling
 

--- a/vocabulary-v4.json
+++ b/vocabulary-v4.json
@@ -8,6 +8,8 @@
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-health-message.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-parameter.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-source.json",
-        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-stream.json"
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-stream.json",
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/edge.json",
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/edge-health-message.json"
     ]
 } 


### PR DESCRIPTION
## PR Classification
Feature addition: introduces windowed and snapshot telemetry restructuring for the edge health message in DTDL/V4 and documentation updates.

## PR Summary

**New files**
| File | Description |
|---|---|
| `DTDL/V4/edge/edge-health-message.json` | v2 edge health message split into `Snapshot` (point-in-time) and `Windowed` (accumulated since last tick) telemetry |
| `DTDL/V4/edge/edge.json` | Edge device interface (v4) referencing the new health message component |
| `CLAUDE.md` | Repo instructions covering DTDL versioning model, `@context` conventions, and vocabulary file rules |

**Updated files**
| File | Description |
|---|---|
| `vocabulary-v4.json` | Added raw URLs for new `edge.json` and `edge-health-message.json` |
| `README.md` | Notes DTDL v4 spans V2–V4 folders, adds Versioning section pointing to CLAUDE.md |