### PR TITLE
feat: add Modbus source models

### DIFF
--- a/DTDL/V4/edge/edge.json
+++ b/DTDL/V4/edge/edge.json
@@ -77,6 +77,15 @@
     },
     {
       "@type": "Relationship",
+      "name": "ModbusSource",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 1,
+      "target": "dtmi:io:tributech:source:modbus",
+      "displayName": "Sources",
+      "description": "Contain Modbus source of the given device."
+    },
+    {
+      "@type": "Relationship",
       "name": "ChangeTrackerStream",
       "minMultiplicity": 0,
       "maxMultiplicity": 1,

--- a/DTDL/V4/edge/modbus/modbus-health-message.json
+++ b/DTDL/V4/edge/modbus/modbus-health-message.json
@@ -1,0 +1,13 @@
+{
+    "@context": [
+        "dtmi:dtdl:context;4",
+        "dtmi:dtdl:extension:annotation;2"
+    ],
+    "@id": "dtmi:io:tributech:healthmessage:modbus;1",
+    "@type": "Interface",
+    "extends": [
+        "dtmi:io:tributech:healthmessage:base;1"
+    ],
+    "displayName": "Modbus Source Health",
+    "contents": []
+}

--- a/DTDL/V4/edge/modbus/modbus-source.json
+++ b/DTDL/V4/edge/modbus/modbus-source.json
@@ -1,0 +1,57 @@
+{
+    "@context": "dtmi:dtdl:context;4",
+    "@id": "dtmi:io:tributech:source:modbus;2",
+    "@type": "Interface",
+    "extends": "dtmi:io:tributech:source:base;2",
+    "displayName": "Modbus Source",
+    "contents": [
+        {
+            "@type": "Property",
+            "name": "Host",
+            "schema": "string",
+            "writable": true,
+            "displayName": "Modbus Host",
+            "description": "The Modbus TCP device IP address or hostname (eg. \"10.0.0.5\")."
+        },
+        {
+            "@type": "Property",
+            "name": "Port",
+            "schema": "integer",
+            "writable": true,
+            "displayName": "Modbus Port",
+            "description": "The Modbus TCP port (eg. 502, the Modbus default)."
+        },
+        {
+            "@type": "Property",
+            "name": "UnitIdentifier",
+            "schema": "integer",
+            "writable": true,
+            "displayName": "Modbus Unit Identifier",
+            "description": "The Modbus unit identifier (0-255) of the target device. Conventionally 255 for a directly addressed Modbus TCP device; meaningful when the TCP endpoint is a gateway bridging to serial units."
+        },
+        {
+            "@type": "Property",
+            "name": "PollingInterval",
+            "schema": "duration",
+            "writable": true,
+            "displayName": "Modbus Polling Interval",
+            "description": "The cyclic poll interval for reading all configured streams (eg. \"PT1S\" for 1 second). Modbus TCP has no server-initiated notifications, so the source must poll for values."
+        },
+        {
+            "@type": "Relationship",
+            "name": "Streams",
+            "minMultiplicity": 0,
+            "maxMultiplicity": 500,
+            "target": "dtmi:io:tributech:stream:modbus",
+            "displayName": "Streams",
+            "description": "Contains all Modbus streams of the given source."
+        },
+        {
+            "@type": "Component",
+            "name": "Health",
+            "schema": "dtmi:io:tributech:healthmessage:modbus;1",
+            "displayName": "Modbus Source Health",
+            "description": "Health message with Modbus source specific health information."
+        }
+    ]
+}

--- a/DTDL/V4/edge/modbus/modbus-stream.json
+++ b/DTDL/V4/edge/modbus/modbus-stream.json
@@ -1,0 +1,39 @@
+{
+    "@context": "dtmi:dtdl:context;4",
+    "@id": "dtmi:io:tributech:stream:modbus;1",
+    "@type": "Interface",
+    "extends": "dtmi:io:tributech:stream:edge:base;2",
+    "displayName": "Modbus Stream",
+    "contents": [
+        {
+            "@type": "Property",
+            "name": "Identifier",
+            "schema": "string",
+            "writable": true,
+            "displayName": "Identifier",
+            "description": "The Modbus register table and zero-based address of the datum to read: a table prefix (\"CO\" coil/FC01, \"DI\" discrete input/FC02, \"HR\" holding register/FC03, \"IR\" input register/FC04) followed by \":\" and the zero-based address 0-65535 (eg. \"HR:100\", \"IR:30\", \"CO:5\", \"DI:2\"). Multi-register values (32/64-bit) start at this address and span the register count implied by Datatype."
+        },
+        {
+            "@type": "Property",
+            "name": "Datatype",
+            "writable": true,
+            "displayName": "Modbus Datatype",
+            "description": "The wire type of the value, which determines the register/bit count read from Identifier onwards and the .NET decoding (eg. \"FLOAT32\"). BOOL is only valid with CO/DI identifiers; the numeric types only with HR/IR identifiers.",
+            "schema": {
+                "@type": "Enum",
+                "valueSchema": "string",
+                "enumValues": [
+                    { "name": "BOOL", "displayName": "Boolean", "enumValue": "BOOL", "comment": ".NET Type: System.Boolean. 1 bit, CO/DI only." },
+                    { "name": "INT16", "displayName": "INT16 (Integer 16)", "enumValue": "INT16", "comment": ".NET Type: System.Int16. 1 register, big-endian." },
+                    { "name": "UINT16", "displayName": "UINT16 (Unsigned Integer 16)", "enumValue": "UINT16", "comment": ".NET Type: System.UInt16. 1 register, big-endian." },
+                    { "name": "INT32", "displayName": "INT32 (Integer 32)", "enumValue": "INT32", "comment": ".NET Type: System.Int32. 2 registers, most-significant-word first." },
+                    { "name": "UINT32", "displayName": "UINT32 (Unsigned Integer 32)", "enumValue": "UINT32", "comment": ".NET Type: System.UInt32. 2 registers, most-significant-word first." },
+                    { "name": "INT64", "displayName": "INT64 (Integer 64)", "enumValue": "INT64", "comment": ".NET Type: System.Int64. 4 registers, most-significant-word first." },
+                    { "name": "UINT64", "displayName": "UINT64 (Unsigned Integer 64)", "enumValue": "UINT64", "comment": ".NET Type: System.UInt64. 4 registers, most-significant-word first." },
+                    { "name": "FLOAT32", "displayName": "FLOAT32 (Float)", "enumValue": "FLOAT32", "comment": ".NET Type: System.Single. 2 registers, IEEE 754, most-significant-word first." },
+                    { "name": "FLOAT64", "displayName": "FLOAT64 (Double)", "enumValue": "FLOAT64", "comment": ".NET Type: System.Double. 4 registers, IEEE 754, most-significant-word first." }
+                ]
+            }
+        }
+    ]
+}

--- a/vocabulary-v4.json
+++ b/vocabulary-v4.json
@@ -9,6 +9,9 @@
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-parameter.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-source.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-stream.json",
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/modbus/modbus-health-message.json",
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/modbus/modbus-source.json",
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/modbus/modbus-stream.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/edge.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/edge-health-message.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/edge-stream.json"


### PR DESCRIPTION
## PR Classification
Feature addition — adds the Modbus DTDL models (source, stream, health message) and wires them into the Edge device and V4 vocabulary manifest.

## PR Summary

**New files**
| File | Description |
|---|---|
| `DTDL/V4/edge/modbus/modbus-source.json` | Modbus source model — Host/Port/UnitIdentifier/PollingInterval, Streams relationship, Health component |
| `DTDL/V4/edge/modbus/modbus-stream.json` | Modbus stream model — Identifier (register address) + Datatype enum |
| `DTDL/V4/edge/modbus/modbus-health-message.json` | Modbus health message — empty contents, base health model only |

**Updated files**
| File | Description |
|---|---|
| `DTDL/V4/edge/edge.json` | Adds `ModbusSource` relationship (0..1) so a Modbus source can attach to an edge twin |
| `vocabulary-v4.json` | Adds raw-GitHub URLs for the three new Modbus model files |
