### PR TITLE
feat: add Modbus V4 twin models

### DIFF
--- a/DTDL/V4/edge/edge.json
+++ b/DTDL/V4/edge/edge.json
@@ -32,6 +32,15 @@
     },
     {
       "@type": "Relationship",
+      "name": "ModbusSource",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 1,
+      "target": "dtmi:io:tributech:source:modbus",
+      "displayName": "Sources",
+      "description": "Contain Modbus source of the given device."
+    },
+    {
+      "@type": "Relationship",
       "name": "MqttSource",
       "minMultiplicity": 0,
       "maxMultiplicity": 1,

--- a/DTDL/V4/edge/modbus/modbus-health-message.json
+++ b/DTDL/V4/edge/modbus/modbus-health-message.json
@@ -1,0 +1,13 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:annotation;2"
+  ],
+  "@id": "dtmi:io:tributech:healthmessage:modbus;1",
+  "@type": "Interface",
+  "extends": [
+    "dtmi:io:tributech:healthmessage:base;1"
+  ],
+  "displayName": "Modbus Source Health",
+  "contents": []
+}

--- a/DTDL/V4/edge/modbus/modbus-parameter.json
+++ b/DTDL/V4/edge/modbus/modbus-parameter.json
@@ -1,0 +1,128 @@
+{
+  "@context": "dtmi:dtdl:context;4",
+  "@id": "dtmi:io:tributech:parameter:modbus;1",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:parameter:base;2",
+  "displayName": "Modbus Parameter",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "Identifier",
+      "schema": "string",
+      "writable": true,
+      "displayName": "Identifier",
+      "description": "The address of the Modbus datum to write to, as <TABLE>:<0-based address>. Only the writable tables are allowed: HR (holding registers) and CO (coils). E.g. \"HR:100\" writes holding register 100 (traditional number 40101), \"CO:5\" writes coil 5. Must be unique across the parameters of a source."
+    },
+    {
+      "@type": "Property",
+      "name": "Value",
+      "schema": "string",
+      "writable": true,
+      "displayName": "Write Value",
+      "description": "Value which will be written to the Modbus address (e.g. \"1.5\" for a FLOAT32, \"42\" for an INT16 or \"true\" for a BOOL)."
+    },
+    {
+      "@type": "Property",
+      "name": "Datatype",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+          {
+            "name": "BOOL",
+            "enumValue": "BOOL",
+            "displayName": "Boolean",
+            "description": "Single bit written to a coil.",
+            "comment": "Maps to System.Boolean. Only valid for CO addresses."
+          },
+          {
+            "name": "INT16",
+            "enumValue": "INT16",
+            "displayName": "Signed 16-bit integer",
+            "description": "Signed 16-bit integer in one register.",
+            "comment": "Maps to System.Int16. Occupies 1 register. Only valid for HR addresses."
+          },
+          {
+            "name": "UINT16",
+            "enumValue": "UINT16",
+            "displayName": "Unsigned 16-bit integer",
+            "description": "Unsigned 16-bit integer in one register.",
+            "comment": "Maps to System.UInt16. Occupies 1 register. Only valid for HR addresses."
+          },
+          {
+            "name": "INT32",
+            "enumValue": "INT32",
+            "displayName": "Signed 32-bit integer",
+            "description": "Signed 32-bit integer in two consecutive registers.",
+            "comment": "Maps to System.Int32. Occupies 2 registers. Only valid for HR addresses."
+          },
+          {
+            "name": "UINT32",
+            "enumValue": "UINT32",
+            "displayName": "Unsigned 32-bit integer",
+            "description": "Unsigned 32-bit integer in two consecutive registers.",
+            "comment": "Maps to System.UInt32. Occupies 2 registers. Only valid for HR addresses."
+          },
+          {
+            "name": "INT64",
+            "enumValue": "INT64",
+            "displayName": "Signed 64-bit integer",
+            "description": "Signed 64-bit integer in four consecutive registers.",
+            "comment": "Maps to System.Int64. Occupies 4 registers. Only valid for HR addresses."
+          },
+          {
+            "name": "UINT64",
+            "enumValue": "UINT64",
+            "displayName": "Unsigned 64-bit integer",
+            "description": "Unsigned 64-bit integer in four consecutive registers.",
+            "comment": "Maps to System.UInt64. Occupies 4 registers. Only valid for HR addresses."
+          },
+          {
+            "name": "FLOAT32",
+            "enumValue": "FLOAT32",
+            "displayName": "32-bit floating point",
+            "description": "IEEE 754 single-precision value in two consecutive registers.",
+            "comment": "Maps to System.Single. Occupies 2 registers. Only valid for HR addresses."
+          },
+          {
+            "name": "FLOAT64",
+            "enumValue": "FLOAT64",
+            "displayName": "64-bit floating point",
+            "description": "IEEE 754 double-precision value in four consecutive registers.",
+            "comment": "Maps to System.Double. Occupies 4 registers. Only valid for HR addresses."
+          }
+        ]
+      },
+      "writable": true,
+      "displayName": "Datatype",
+      "description": "The wire type of the value to write (e.g. \"FLOAT32\"). Modbus registers are raw 16-bit words, so the target type cannot be discovered from the device. BOOL is only valid for CO addresses; all other types only for HR addresses."
+    },
+    {
+      "@type": "Property",
+      "name": "ByteOrder",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+          {
+            "name": "BIG_ENDIAN",
+            "enumValue": "BIG_ENDIAN",
+            "displayName": "Big endian",
+            "description": "Most significant register/byte first (the Modbus specification default, also called ABCD).",
+            "comment": "Default when not set."
+          },
+          {
+            "name": "LITTLE_ENDIAN",
+            "enumValue": "LITTLE_ENDIAN",
+            "displayName": "Little endian",
+            "description": "Least significant register/byte first (DCBA), used by some vendors for multi-register values.",
+            "comment": "Applies to multi-register values (32/64-bit types)."
+          }
+        ]
+      },
+      "writable": true,
+      "displayName": "Byte Order",
+      "description": "Byte/register order used to encode values spanning multiple registers (e.g. \"BIG_ENDIAN\"). Defaults to BIG_ENDIAN (Modbus specification conformant) when not set. Irrelevant for BOOL/INT16/UINT16."
+    }
+  ]
+}

--- a/DTDL/V4/edge/modbus/modbus-source.json
+++ b/DTDL/V4/edge/modbus/modbus-source.json
@@ -1,0 +1,74 @@
+{
+  "@context": "dtmi:dtdl:context;4",
+  "@id": "dtmi:io:tributech:source:modbus;2",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:source:base;2",
+  "displayName": "Modbus Source",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "Host",
+      "schema": "string",
+      "writable": true,
+      "displayName": "Modbus device host",
+      "description": "IP address or host name of the Modbus TCP device (e.g. \"192.168.0.10\" or \"modbus-server\")."
+    },
+    {
+      "@type": "Property",
+      "name": "Port",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Modbus device TCP port",
+      "description": "TCP port of the Modbus device (e.g. 502, the standard Modbus TCP port)."
+    },
+    {
+      "@type": "Property",
+      "name": "UnitIdentifier",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Modbus unit identifier",
+      "description": "Modbus unit identifier used to address the device (e.g. 255 for a directly addressed Modbus TCP server, or 1-247 when routing through a gateway to a serial slave)."
+    },
+    {
+      "@type": "Property",
+      "name": "DefaultReadCycleInterval",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Read cycle default interval (seconds)",
+      "description": "Default poll interval in seconds for streams that do not set their own ReadCycleInterval (e.g. 10)."
+    },
+    {
+      "@type": "Property",
+      "name": "WriteCycleInterval",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Modbus write cycle interval",
+      "description": "The Modbus write cycle interval in seconds (e.g. 10) for writing values to the Modbus device with parameters."
+    },
+    {
+      "@type": "Relationship",
+      "name": "Streams",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 100,
+      "target": "dtmi:io:tributech:stream:modbus",
+      "displayName": "Streams",
+      "description": "Contains all Modbus streams of the given source."
+    },
+    {
+      "@type": "Relationship",
+      "name": "Parameter",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 100,
+      "target": "dtmi:io:tributech:parameter:modbus",
+      "displayName": "Parameters",
+      "description": "For writing configuration values to the Modbus device."
+    },
+    {
+      "@type": "Component",
+      "name": "Health",
+      "schema": "dtmi:io:tributech:healthmessage:modbus;1",
+      "displayName": "Modbus Source Health",
+      "description": "Health message with Modbus source specific health information."
+    }
+  ]
+}

--- a/DTDL/V4/edge/modbus/modbus-stream.json
+++ b/DTDL/V4/edge/modbus/modbus-stream.json
@@ -1,0 +1,128 @@
+{
+  "@context": "dtmi:dtdl:context;4",
+  "@id": "dtmi:io:tributech:stream:modbus;1",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:stream:edge:base;2",
+  "displayName": "Modbus Stream",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "Identifier",
+      "schema": "string",
+      "writable": true,
+      "displayName": "Identifier",
+      "description": "The address of the Modbus datum to be read, as <TABLE>:<0-based address>. Table prefixes: CO (coils), DI (discrete inputs), IR (input registers), HR (holding registers). E.g. \"HR:100\" reads holding register 100 (traditional number 40101), \"IR:30\" input register 30 (30031), \"CO:5\" coil 5, \"DI:2\" discrete input 2. Must be unique across the streams of a source."
+    },
+    {
+      "@type": "Property",
+      "name": "Datatype",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+          {
+            "name": "BOOL",
+            "enumValue": "BOOL",
+            "displayName": "Boolean",
+            "description": "Single bit read from a coil or discrete input.",
+            "comment": "Maps to System.Boolean. Only valid for CO and DI addresses."
+          },
+          {
+            "name": "INT16",
+            "enumValue": "INT16",
+            "displayName": "Signed 16-bit integer",
+            "description": "Signed 16-bit integer in one register.",
+            "comment": "Maps to System.Int16. Occupies 1 register. Only valid for IR and HR addresses."
+          },
+          {
+            "name": "UINT16",
+            "enumValue": "UINT16",
+            "displayName": "Unsigned 16-bit integer",
+            "description": "Unsigned 16-bit integer in one register.",
+            "comment": "Maps to System.UInt16. Occupies 1 register. Only valid for IR and HR addresses."
+          },
+          {
+            "name": "INT32",
+            "enumValue": "INT32",
+            "displayName": "Signed 32-bit integer",
+            "description": "Signed 32-bit integer in two consecutive registers.",
+            "comment": "Maps to System.Int32. Occupies 2 registers. Only valid for IR and HR addresses."
+          },
+          {
+            "name": "UINT32",
+            "enumValue": "UINT32",
+            "displayName": "Unsigned 32-bit integer",
+            "description": "Unsigned 32-bit integer in two consecutive registers.",
+            "comment": "Maps to System.UInt32. Occupies 2 registers. Only valid for IR and HR addresses."
+          },
+          {
+            "name": "INT64",
+            "enumValue": "INT64",
+            "displayName": "Signed 64-bit integer",
+            "description": "Signed 64-bit integer in four consecutive registers.",
+            "comment": "Maps to System.Int64. Occupies 4 registers. Only valid for IR and HR addresses."
+          },
+          {
+            "name": "UINT64",
+            "enumValue": "UINT64",
+            "displayName": "Unsigned 64-bit integer",
+            "description": "Unsigned 64-bit integer in four consecutive registers.",
+            "comment": "Maps to System.UInt64. Occupies 4 registers. Only valid for IR and HR addresses."
+          },
+          {
+            "name": "FLOAT32",
+            "enumValue": "FLOAT32",
+            "displayName": "32-bit floating point",
+            "description": "IEEE 754 single-precision value in two consecutive registers.",
+            "comment": "Maps to System.Single. Occupies 2 registers. Only valid for IR and HR addresses."
+          },
+          {
+            "name": "FLOAT64",
+            "enumValue": "FLOAT64",
+            "displayName": "64-bit floating point",
+            "description": "IEEE 754 double-precision value in four consecutive registers.",
+            "comment": "Maps to System.Double. Occupies 4 registers. Only valid for IR and HR addresses."
+          }
+        ]
+      },
+      "writable": true,
+      "displayName": "Datatype",
+      "description": "The wire type of the Modbus datum (e.g. \"FLOAT32\"). Modbus registers are raw 16-bit words, so the type cannot be discovered from the device. BOOL is only valid for CO/DI addresses; all other types only for IR/HR addresses."
+    },
+    {
+      "@type": "Property",
+      "name": "ByteOrder",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+          {
+            "name": "BIG_ENDIAN",
+            "enumValue": "BIG_ENDIAN",
+            "displayName": "Big endian",
+            "description": "Most significant register/byte first (the Modbus specification default, also called ABCD).",
+            "comment": "Default when not set."
+          },
+          {
+            "name": "LITTLE_ENDIAN",
+            "enumValue": "LITTLE_ENDIAN",
+            "displayName": "Little endian",
+            "description": "Least significant register/byte first (DCBA), used by some vendors for multi-register values.",
+            "comment": "Applies to multi-register values (32/64-bit types)."
+          }
+        ]
+      },
+      "writable": true,
+      "displayName": "Byte Order",
+      "description": "Byte/register order used to decode values spanning multiple registers (e.g. \"BIG_ENDIAN\"). Defaults to BIG_ENDIAN (Modbus specification conformant) when not set. Irrelevant for BOOL/INT16/UINT16."
+    },
+    {
+      "@type": "Property",
+      "name": "ReadCycleInterval",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Reading cycle interval",
+      "description": "Poll interval in seconds for this stream (e.g. 10). When not set, defaults to the source's DefaultReadCycleInterval."
+    }
+  ]
+}

--- a/vocabulary-v4.json
+++ b/vocabulary-v4.json
@@ -5,6 +5,10 @@
     "issuerURL": "https://tributech.io",
     "documentationURL": "https://github.com/tributech-solutions/data-asset-twin-v2",
     "references": [
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/modbus/modbus-health-message.json",
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/modbus/modbus-parameter.json",
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/modbus/modbus-source.json",
+        "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/modbus/modbus-stream.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-health-message.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-parameter.json",
         "https://raw.githubusercontent.com/tributech-solutions/data-asset-twin-v2/master/DTDL/V4/edge/opcua/opcua-source.json",


### PR DESCRIPTION
## PR Classification
Feature addition: adds the V4 Modbus twin models (source, stream, parameter, health message) and wires them into the edge device model and vocabulary.

## PR Summary

**New files** (only files with status A)
| File | Description |
|---|---|
| `DTDL/V4/edge/modbus/modbus-source.json` | Modbus source twin (`source:modbus;2`): host, port, unit, intervals |
| `DTDL/V4/edge/modbus/modbus-stream.json` | Modbus stream twin (`stream:modbus;1`): identifier, datatype, byte order, interval |
| `DTDL/V4/edge/modbus/modbus-parameter.json` | Modbus parameter twin (`parameter:modbus;1`): cyclic set-point writes |
| `DTDL/V4/edge/modbus/modbus-health-message.json` | Modbus health message (`healthmessage:modbus;1`), no extra indicators |

**Updated files** (only files with status M or D)
| File | Description |
|---|---|
| `DTDL/V4/edge/edge.json` | Adds `ModbusSource` relationship (0..1) to `device:edge;4` |
| `vocabulary-v4.json` | Registers the four new Modbus model URLs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
